### PR TITLE
Fix: Japanese translation in Japanese

### DIFF
--- a/Model/PluginLanguage.cs
+++ b/Model/PluginLanguage.cs
@@ -12,7 +12,7 @@ namespace DalamudPluginCommon
 		public static readonly PluginLanguage English = new PluginLanguage(1, "English", "en");
 		public static readonly PluginLanguage German = new PluginLanguage(2, "Deutsche", "de");
 		public static readonly PluginLanguage French = new PluginLanguage(3, "Français", "fr");
-		public static readonly PluginLanguage Japanese = new PluginLanguage(4, "日本人", "ja");
+		public static readonly PluginLanguage Japanese = new PluginLanguage(4, "日本語", "ja");
 		public static readonly PluginLanguage Spanish = new PluginLanguage(5, "Español", "es");
 		public static readonly PluginLanguage Italian = new PluginLanguage(6, "Italiano", "it");
 		public static readonly PluginLanguage Norwegian = new PluginLanguage(7, "Norsk", "no");


### PR DESCRIPTION
The using of the word "日本人" in this code is wrong. 
"日本人" means Japanese people, while "日本语" means Japanese language.

By the way, do you have a plan to add Korean, Simplified Chinese and Traditional Chinese as well?